### PR TITLE
Add a proxy to allow communication from different domains

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    async rewrites() {
+        return [
+            {
+                source: '/backend/:path*',
+                destination: process.env.NEXT_PUBLIC_BACKEND_URL + '/:path*',
+            },
+        ]
+    },
+}

--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -1,7 +1,7 @@
 import Axios from 'axios'
 
 const axios = Axios.create({
-    baseURL: process.env.NEXT_PUBLIC_BACKEND_URL,
+    baseURL: 'backend',
     headers: {
         'X-Requested-With': 'XMLHttpRequest',
     },


### PR DESCRIPTION
Eliminate the need to run `php artisan serve` to have the same `localhost` domain in both projects.
For example, with Valet, just add the domain in the `.env.local`file in the next project:
```js
NEXT_PUBLIC_BACKEND_URL=http://laravel-api.test
```