### PR TITLE
fix .eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,6 @@ module.exports = {
         'react/react-in-jsx-scope': 0,
         'linebreak-style': ['error', 'unix'],
         semi: ['error', 'never'],
-        'prettier/prettier': ['error', { "endOfLine": "off"}, { usePrettierrc: true }],
+        'prettier/prettier': ['error', { "endOfLine": "off" }, { usePrettierrc: true }],
     },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,6 @@ module.exports = {
         'react/react-in-jsx-scope': 0,
         'linebreak-style': ['error', 'unix'],
         semi: ['error', 'never'],
-        'prettier/prettier': ['error', {}, { usePrettierrc: true }],
+        'prettier/prettier': ['error', { "endOfLine": "off"}, { usePrettierrc: true }],
     },
 }


### PR DESCRIPTION
after run npm run build have many error for enter line , etc in components According to this issue https://github.com/prettier/eslint-plugin-prettier/issues/219#issuecomment-827161526 solved




./src/components/AuthCard.js
1:43  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
1:43  Error: Delete `␍`  prettier/prettier
2:105  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
2:105  Error: Delete `␍`  prettier/prettier
3:26  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
3:26  Error: Delete `␍`  prettier/prettier
4:1  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
4:1  Error: Delete `␍`  prettier/prettier
5:109  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
5:109  Error: Delete `␍`  prettier/prettier
6:23  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
6:23  Error: Delete `␍`  prettier/prettier
7:15  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
7:15  Error: Delete `␍`  prettier/prettier
8:11  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
8:11  Error: Delete `␍`  prettier/prettier
9:2  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
9:2  Error: Delete `␍`  prettier/prettier
10:1  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
10:1  Error: Delete `␍`  prettier/prettier
11:24  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
11:24  Error: Delete `␍`  prettier/prettier

./src/components/AuthSessionStatus.js
1:65  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
1:65  Error: Delete `␍`  prettier/prettier
2:7  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
2:7  Error: Delete `␍`  prettier/prettier
3:21  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
3:21  Error: Delete `␍`  prettier/prettier
4:17  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
4:17  Error: Delete `␍`  prettier/prettier
5:78  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
5:78  Error: Delete `␍`  prettier/prettier
6:28  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
6:28  Error: Delete `␍`  prettier/prettier
7:25  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
7:25  Error: Delete `␍`  prettier/prettier
8:19  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
8:19  Error: Delete `␍`  prettier/prettier
9:11  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
9:11  Error: Delete `␍`  prettier/prettier
10:8  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
10:8  Error: Delete `␍`  prettier/prettier
11:2  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
11:2  Error: Delete `␍`  prettier/prettier
12:1  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
12:1  Error: Delete `␍`  prettier/prettier
13:33  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
13:33  Error: Delete `␍`  prettier/prettier

./src/components/AuthValidationErrors.js
1:62  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
1:62  Error: Delete `␍`  prettier/prettier
2:7  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
2:7  Error: Delete `␍`  prettier/prettier
3:32  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
3:32  Error: Delete `␍`  prettier/prettier
4:29  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
4:29  Error: Delete `␍`  prettier/prettier
5:59  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
5:59  Error: Delete `␍`  prettier/prettier
6:50  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
6:50  Error: Delete `␍`  prettier/prettier
7:23  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
7:23  Error: Delete `␍`  prettier/prettier
8:1  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
8:1  Error: Delete `␍`  prettier/prettier
9:81  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
9:81  Error: Delete `␍`  prettier/prettier
10:43  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
10:43  Error: Delete `␍`  prettier/prettier
11:53  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
11:53  Error: Delete `␍`  prettier/prettier
12:24  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
12:24  Error: Delete `␍`  prettier/prettier
13:22  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
13:22  Error: Delete `␍`  prettier/prettier
14:19  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
14:19  Error: Delete `␍`  prettier/prettier
15:11  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
15:11  Error: Delete `␍`  prettier/prettier
16:8  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
16:8  Error: Delete `␍`  prettier/prettier
17:2  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
17:2  Error: Delete `␍`  prettier/prettier
18:1  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
18:1  Error: Delete `␍`  prettier/prettier
19:36  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
19:36  Error: Delete `␍`  prettier/prettier

./src/components/Button.js
1:63  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
1:63  Error: Delete `␍`  prettier/prettier
2:12  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
2:12  Error: Delete `␍`  prettier/prettier
3:20  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
3:20  Error: Delete `␍`  prettier/prettier
4:337  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
4:337  Error: Delete `␍`  prettier/prettier
5:19  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
5:19  Error: Delete `␍`  prettier/prettier
6:7  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
6:7  Error: Delete `␍`  prettier/prettier
7:2  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
7:2  Error: Delete `␍`  prettier/prettier
8:1  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
8:1  Error: Delete `␍`  prettier/prettier
9:22  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
9:22  Error: Delete `␍`  prettier/prettier

./src/components/Dropdown.js
1:40  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
1:40  Error: Delete `␍`  prettier/prettier
2:53  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
2:53  Error: Delete `␍`  prettier/prettier
3:1  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
3:1  Error: Delete `␍`  prettier/prettier
4:20  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
4:20  Error: Delete `␍`  prettier/prettier
5:21  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
5:21  Error: Delete `␍`  prettier/prettier
6:16  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
6:16  Error: Delete `␍`  prettier/prettier
7:38  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
7:38  Error: Delete `␍`  prettier/prettier
8:13  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
8:13  Error: Delete `␍`  prettier/prettier
9:14  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
9:14  Error: Delete `␍`  prettier/prettier
10:8  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
10:8  Error: Delete `␍`  prettier/prettier
11:25  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
11:25  Error: Delete `␍`  prettier/prettier
12:1  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
12:1  Error: Delete `␍`  prettier/prettier
13:21  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
13:21  Error: Delete `␍`  prettier/prettier
14:19  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
14:19  Error: Delete `␍`  prettier/prettier
15:27  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
15:27  Error: Delete `␍`  prettier/prettier
16:18  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
16:18  Error: Delete `␍`  prettier/prettier
17:6  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
17:6  Error: Delete `␍`  prettier/prettier
18:1  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
18:1  Error: Delete `␍`  prettier/prettier
19:21  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
19:21  Error: Delete `␍`  prettier/prettier
20:21  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
20:21  Error: Delete `␍`  prettier/prettier
21:56  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
21:56  Error: Delete `␍`  prettier/prettier
22:18  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
22:18  Error: Delete `␍`  prettier/prettier
23:20  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
23:20  Error: Delete `␍`  prettier/prettier
24:44  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
24:44  Error: Delete `␍`  prettier/prettier
25:18  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
25:18  Error: Delete `␍`  prettier/prettier
26:22  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
26:22  Error: Delete `␍`  prettier/prettier
27:17  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
27:17  Error: Delete `␍`  prettier/prettier
28:58  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
28:58  Error: Delete `␍`  prettier/prettier
29:18  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
29:18  Error: Delete `␍`  prettier/prettier
30:6  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
30:6  Error: Delete `␍`  prettier/prettier
31:1  Error: Expected linebreaks to be 'LF' but found 'CRLF'.  linebreak-style
31:1  Error: Delete `␍`  prettier/prettier