### PR TITLE
Fix inconsistencies and add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
+# env files
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/src/hooks/auth.js
+++ b/src/hooks/auth.js
@@ -76,7 +76,7 @@ export const useAuth = ({ middleware, redirectIfAuthenticated } = {}) => {
             .post('/reset-password', { token: router.query.token, ...props })
             .then(response => router.push('/login?reset=' + btoa(response.data.status)))
             .catch(error => {
-                if (error.response.status != 422) throw error
+                if (error.response.status !== 422) throw error
 
                 setErrors(Object.values(error.response.data.errors).flat())
             })

--- a/src/pages/password-reset/[token].js
+++ b/src/pages/password-reset/[token].js
@@ -18,7 +18,7 @@ const PasswordReset = () => {
 
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
-    const [password_confirmation, setPasswordConfirmation] = useState('')
+    const [passwordConfirmation, setPasswordConfirmation] = useState('')
     const [errors, setErrors] = useState([])
     const [status, setStatus] = useState(null)
 
@@ -28,7 +28,7 @@ const PasswordReset = () => {
         resetPassword({
             email,
             password,
-            password_confirmation,
+            passwordConfirmation,
             setErrors,
             setStatus,
         })
@@ -48,7 +48,6 @@ const PasswordReset = () => {
                         </a>
                     </Link>
                 }>
-
                 {/* Session Status */}
                 <AuthSessionStatus className="mb-4" status={status} />
 
@@ -86,14 +85,14 @@ const PasswordReset = () => {
 
                     {/* Confirm Password */}
                     <div className="mt-4">
-                        <Label htmlFor="password_confirmation">
+                        <Label htmlFor="passwordConfirmation">
                             Confirm Password
                         </Label>
 
                         <Input
-                            id="password_confirmation"
+                            id="passwordConfirmation"
                             type="password"
-                            value={password_confirmation}
+                            value={passwordConfirmation}
                             className="block mt-1 w-full"
                             onChange={event =>
                                 setPasswordConfirmation(event.target.value)

--- a/src/pages/password-reset/[token].js
+++ b/src/pages/password-reset/[token].js
@@ -28,7 +28,7 @@ const PasswordReset = () => {
         resetPassword({
             email,
             password,
-            passwordConfirmation,
+            password_confirmation: passwordConfirmation,
             setErrors,
             setStatus,
         })

--- a/src/pages/register.js
+++ b/src/pages/register.js
@@ -18,13 +18,13 @@ const Register = () => {
     const [name, setName] = useState('')
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
-    const [password_confirmation, setPasswordConfirmation] = useState('')
+    const [passwordConfirmation, setPasswordConfirmation] = useState('')
     const [errors, setErrors] = useState([])
 
     const submitForm = event => {
         event.preventDefault()
 
-        register({ name, email, password, password_confirmation, setErrors })
+        register({ name, email, password, passwordConfirmation, setErrors })
     }
 
     return (
@@ -37,7 +37,6 @@ const Register = () => {
                         </a>
                     </Link>
                 }>
-
                 {/* Validation Errors */}
                 <AuthValidationErrors className="mb-4" errors={errors} />
 
@@ -88,14 +87,14 @@ const Register = () => {
 
                     {/* Confirm Password */}
                     <div className="mt-4">
-                        <Label htmlFor="password_confirmation">
+                        <Label htmlFor="passwordConfirmation">
                             Confirm Password
                         </Label>
 
                         <Input
-                            id="password_confirmation"
+                            id="passwordConfirmation"
                             type="password"
-                            value={password_confirmation}
+                            value={passwordConfirmation}
                             className="block mt-1 w-full"
                             onChange={event =>
                                 setPasswordConfirmation(event.target.value)

--- a/src/pages/register.js
+++ b/src/pages/register.js
@@ -24,7 +24,7 @@ const Register = () => {
     const submitForm = event => {
         event.preventDefault()
 
-        register({ name, email, password, passwordConfirmation, setErrors })
+        register({ name, email, password, password_confirmation: passwordConfirmation, setErrors })
     }
 
     return (


### PR DESCRIPTION
This PR resolves:
- Variable naming inconsistencies such as `password_confirmation` instead of passwordConfirmation
- Add .env to gitignore to prevent accidental commit
- Use `===` instead of `==` in `resetPassword` auth hooks