### PR TITLE
Add named routes tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ export default ExamplePage
 
 > Note: You will need to use [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) (`user?.name` instead of `user.name`) when accessing properties on the user object to account for Next.js's initial server-side render.
 
+### Using Laravel Named Routes
+
+You'll need to take additional steps in order to use your backend Laravel named routes within your frontend app's React components. Luckily there is a package named [Ziggy](https://github.com/tighten/ziggy#spas-or-separate-repos) by Tighten that you can use to communicate the routes to your frontend.
+
+
+
 ## Contributing
 
 Thank you for considering contributing to Breeze Next! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).

--- a/README.md
+++ b/README.md
@@ -67,11 +67,9 @@ export default ExamplePage
 
 > Note: You will need to use [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) (`user?.name` instead of `user.name`) when accessing properties on the user object to account for Next.js's initial server-side render.
 
-### Using Laravel Named Routes
+### Named Routes
 
-You'll need to take additional steps in order to use your backend Laravel named routes within your frontend app's React components. Luckily there is a package named [Ziggy](https://github.com/tighten/ziggy#spas-or-separate-repos) by Tighten that you can use to communicate the routes to your frontend.
-
-
+For convenience, [Ziggy](https://github.com/tighten/ziggy#spas-or-separate-repos) may be used in order to reference your Laravel application's named route URLs from your React application.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ export default ExamplePage
 
 ### Named Routes
 
-For convenience, [Ziggy](https://github.com/tighten/ziggy#spas-or-separate-repos) may be used in order to reference your Laravel application's named route URLs from your React application.
+For convenience, [Ziggy](https://github.com/tighten/ziggy#spas-or-separate-repos) may be used to reference your Laravel application's named route URLs from your React application.
 
 ## Contributing
 


### PR DESCRIPTION
```js
axios.post(`posts/${parent.id}/replies`)
```
```js
axios.post(route('replies.store', parent.id))
```
This may be out of the scope of what this package's docs should cover

I just thought it helpful to mention as I did a little digging. 

https://github.com/tighten/ziggy#spas-or-separate-repos