### PR TITLE
change btoa and atob to encodeURI and decodeURI

### DIFF
--- a/src/hooks/auth.js
+++ b/src/hooks/auth.js
@@ -74,7 +74,7 @@ export const useAuth = ({ middleware, redirectIfAuthenticated } = {}) => {
 
         axios
             .post('/reset-password', { token: router.query.token, ...props })
-            .then(response => router.push('/login?reset=' + btoa(response.data.status)))
+            .then(response => router.push('/login?reset=' + encodeURI(response.data.status)))
             .catch(error => {
                 if (error.response.status !== 422) throw error
 

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -26,7 +26,7 @@ const Login = () => {
 
     useEffect(() => {
         if (router.query.reset?.length > 0 && errors.length === 0) {
-            setStatus(atob(router.query.reset))
+            setStatus(decodeURI(router.query.reset))
         } else {
             setStatus(null)
         }


### PR DESCRIPTION
I'm not sure this repository accept a pull request but I found something to report.

In hooks/auth.js, resetPassword uses **btoa** to encode URI. However, btoa can not handle multi-byte character such as Japanese. If I put Japanese for 'reset' key in lang/ja/passwords.php, it makes an error and can not proceed when I try to reset password.

If I use **encodeURI and decodeURI** instead of **btoa and atob**, then it works as expected. It works for English as well as multi-byte character. I believe btoa should be replaced anyway because it is deprecated.

This is my first time to do a pull request. I hope I'm doing it correctly.