### PR TITLE
Upgrade tailwindcss/forms (0.4.0 -> 0.5.2).

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.12.1",
     "@next/eslint-plugin-next": "^10.0.4",
-    "@tailwindcss/forms": "^0.4.0",
+    "@tailwindcss/forms": "^0.5.2",
     "autoprefixer": "^10.4.2",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.17.0",


### PR DESCRIPTION
Upgraded the tailwindcss/forms forms reset package to the latest version, to get rid of repeated deprecation warnings that keept popping up during asset rebuilds:

`(1:1) autoprefixer: Replace color-adjust to print-color-adjust. The color-adjust shorthand is currently deprecated.`

The color-adjust property was changed in version 0.5.1: https://github.com/tailwindlabs/tailwindcss-forms/compare/v0.4.1...v0.5.1