### PR TITLE
Make remember-me checkbox functional

### DIFF
--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -21,6 +21,7 @@ const Login = () => {
 
     const [email, setEmail] = useState('')
     const [password, setPassword] = useState('')
+    const [shouldRemember, setShouldRemember] = useState(false)
     const [errors, setErrors] = useState([])
     const [status, setStatus] = useState(null)
 
@@ -35,7 +36,7 @@ const Login = () => {
     const submitForm = async event => {
         event.preventDefault()
 
-        login({ email, password, setErrors, setStatus })
+        login({ email, password, remember: shouldRemember, setErrors, setStatus })
     }
 
     return (
@@ -96,6 +97,7 @@ const Login = () => {
                                 type="checkbox"
                                 name="remember"
                                 className="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
+                                onChange={event => setShouldRemember(event.target.checked)}
                             />
 
                             <span className="ml-2 text-sm text-gray-600">


### PR DESCRIPTION
Currently, the "Remember me" checkbox is not functional in that its value does not get sent to the backend API.

This pull request makes it so that the checkbox value is sent to the backend API and, subsequently, a `remember_token` is set if the checkbox is enabled.