### PR TITLE
Add link to registration on login page

### DIFF
--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -105,6 +105,11 @@ const Login = () => {
                     </div>
 
                     <div className="flex items-center justify-end mt-4">
+                        <Link href="/register">
+                            <a className="underline text-sm text-gray-600 hover:text-gray-900 mr-2">
+                                Don't have an account?
+                            </a>
+                        </Link>
                         <Link href="/forgot-password">
                             <a className="underline text-sm text-gray-600 hover:text-gray-900">
                                 Forgot your password?


### PR DESCRIPTION
As there is currently no link on the login page to go to the registration page, the way to do this via the UI seems to be to firstly click on the logo at the top and then on the "Register" link in the upper right corner. This might not be intuitive to some people. Therefore, I suggest adding a link to the registration page on the login page, which hopefully, should not overcrowd the interface.