### PR TITLE
adding an `isLoading` indicator from the `auth` hook

### DIFF
--- a/src/hooks/auth.js
+++ b/src/hooks/auth.js
@@ -106,6 +106,7 @@ export const useAuth = ({ middleware, redirectIfAuthenticated } = {}) => {
 
     return {
         user,
+        isLoading: !user && !error,
         register,
         login,
         forgotPassword,


### PR DESCRIPTION
Meanwhile the user's info is getting fetched from the API, `isLoading` can be optionally used for displaying a loading screen (for example).

This is the same logic just as seen in the official docs about SWR (which the `useAuth` hook uses):
https://swr.vercel.app/docs/getting-started#make-it-reusable