### PR TITLE
Changed redirect behavior when logging out and redirecting to login page at @/hooks/auth.js file.

### DIFF
--- a/src/hooks/auth.js
+++ b/src/hooks/auth.js
@@ -94,19 +94,23 @@ export const useAuth = ({ middleware, redirectIfAuthenticated } = {}) => {
         if (! error) {
             await axios.post('/logout').then(() => mutate())
         }
-
-        window.location.pathname = '/login'
     }
 
     useEffect(() => {
-        if (middleware === 'guest' && redirectIfAuthenticated && user)
+        if (middleware === 'guest' && redirectIfAuthenticated && user && !error)
             router.push(redirectIfAuthenticated)
         if (
-            window.location.pathname === '/verify-email' &&
+            router.pathname === '/verify-email' &&
             user?.email_verified_at
         )
             router.push(redirectIfAuthenticated)
-        if (middleware === 'auth' && error) logout()
+        if (
+            router.pathname !== '/login' &&
+            middleware === 'auth' &&
+            (error || user === undefined)
+        ) {
+            router.push('/login');
+        }
     }, [user, error])
 
     return {


### PR DESCRIPTION
Current redirect method to login page after not detecting a valid authenticated user is made by setting window.location.pathname, but it's not recommended to do it this way with nextjs because it won't let nextjs features like events to work properly. Also added '!error' condition when 'guest' pages must redirect an authenticated user to avoid infinite redirect loop with '/logout' route. No changes on logout behavior to the end users.