### PR TITLE
Switching to non-deprecated version of eslint-parser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
     root: true,
-    parser: 'babel-eslint',
+    parser: '@babel/eslint-parser',
     env: {
         node: true,
         browser: true,
@@ -17,6 +17,7 @@ module.exports = {
             jsx: true,
         },
         ecmaVersion: 2020,
+        requireConfigFile: false,
     },
     plugins: ['react', '@next/eslint-plugin-next', 'prettier'],
     rules: {
@@ -38,6 +39,10 @@ module.exports = {
         'react/react-in-jsx-scope': 0,
         'linebreak-style': ['error', 'unix'],
         semi: ['error', 'never'],
-        'prettier/prettier': ['error', { "endOfLine": "off" }, { usePrettierrc: true }],
+        'prettier/prettier': [
+            'error',
+            { endOfLine: 'auto' },
+            { usePrettierrc: true },
+        ],
     },
 }


### PR DESCRIPTION
To avoid getting the following error:

`Parsing error: require() of ES Module node_modules/eslint/node_modules/eslint-scope/lib/definition.js from node_modules/babel-eslint/lib/require-from-eslint.js not supported.`

And an error for not having a Babel config file.
