### PR TITLE
prompts the user to run the database migration before testing the log…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ php artisan breeze:install api
 
 Next, ensure that your application's `APP_URL` and `FRONTEND_URL` environment variables are set to `http://localhost:8000` and `http://localhost:3000`, respectively.
 
+Also, make sure you migrate your database by running
+
+```bash
+# create tables and migrate changes to the database...
+php artisan migrate
+```
+
 After defining the appropriate environment variables, you may serve the Laravel application using the `serve` Artisan command:
 
 ```bash


### PR DESCRIPTION
adjusted the issue when the user tries testing the api/login or api/register route without an existing database
