### PR TITLE
Update axios.js

### DIFF
--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -6,6 +6,7 @@ const axios = Axios.create({
         'X-Requested-With': 'XMLHttpRequest',
     },
     withCredentials: true,
+    withXSRFToken: true
 })
 
 export default axios


### PR DESCRIPTION
"To migrate from the old withCredential behavior (<v1.6.0), you should now use withXSRFToken along with withCredential."

https://github.com/axios/axios/releases/tag/v1.6.2