### PR TITLE
Removed duplicate words from verify-email/page.js

### DIFF
--- a/src/app/(auth)/verify-email/page.js
+++ b/src/app/(auth)/verify-email/page.js
@@ -16,15 +16,15 @@ const Page = () => {
         <>
             <div className="mb-4 text-sm text-gray-600">
                 Thanks for signing up! Before getting started, could you verify
-                verify your email address by clicking on the link we just
+                your email address by clicking on the link we just
                 emailed to you? If you didn't receive the email, we will gladly
-                gladly send you another.
+                send you another.
             </div>
 
             {status === 'verification-link-sent' && (
                 <div className="mb-4 font-medium text-sm text-green-600">
                     A new verification link has been sent to the email address
-                    address you provided during registration.
+                    you provided during registration.
                 </div>
             )}
 


### PR DESCRIPTION
This commit removes 3 duplicate words in page.js. Originally, the text had duplicate words "verify verify" [line 18-19], "gladly gladly" [line 20-21], "address address" [line 26-27]. This commit changes it to single word.
