### PR TITLE
Next/font & updated tailwind config

### DIFF
--- a/src/app/(auth)/layout.js
+++ b/src/app/(auth)/layout.js
@@ -9,7 +9,7 @@ export const metadata = {
 const Layout = ({ children }) => {
     return (
         <div>
-            <div className="font-sans text-gray-900 antialiased">
+            <div className="text-gray-900 antialiased">
                 <AuthCard
                     logo={
                         <Link href="/">

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.bunny.net/css2?family=Nunito:wght@400;600;700&display=swap");
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,14 +1,21 @@
+import { Nunito } from 'next/font/google'
 import '@/app/global.css'
 
-export const metadata = {
-    title: 'Laravel',
-}
+const nunitoFont = Nunito({
+    subsets: ['latin'],
+    display: 'swap',
+})
+
 const RootLayout = ({ children }) => {
     return (
-        <html lang="en">
+        <html lang="en" className={nunitoFont.className}>
             <body className="antialiased">{children}</body>
         </html>
     )
+}
+
+export const metadata = {
+    title: 'Laravel',
 }
 
 export default RootLayout

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,19 +1,5 @@
-const defaultTheme = require('tailwindcss/defaultTheme')
-
 module.exports = {
-    content: ['./src/**/*.js'],
-    darkMode: 'media',
-    theme: {
-        extend: {
-            fontFamily: {
-                sans: ['Nunito', ...defaultTheme.fontFamily.sans],
-            },
-        },
-    },
-    variants: {
-        extend: {
-            opacity: ['disabled'],
-        },
-    },
+    content: ['./src/**/*.{js,jsx,ts,tsx}'],
+    theme: {},
     plugins: [require('@tailwindcss/forms')],
 }


### PR DESCRIPTION
Next.js comes with font optimization out of the box using `next/font`
https://nextjs.org/docs/app/building-your-application/optimizing/fonts

Cleaned up the tailwind config:
- `variants` has been removed since v3: https://tailwindcss.com/docs/upgrade-guide#remove-variant-configuration
- font configuration is implemented by `next/font` 