### PR TITLE
Conditionally push to verification email route only if the user exists and is different than undefined

### DIFF
--- a/src/hooks/auth.js
+++ b/src/hooks/auth.js
@@ -103,7 +103,7 @@ export const useAuth = ({ middleware, redirectIfAuthenticated } = {}) => {
         if (middleware === 'guest' && redirectIfAuthenticated && user)
             router.push(redirectIfAuthenticated)
 
-        if (middleware === 'auth' && (user && !user?.email_verified_at))
+        if (middleware === 'auth' && (user && !user.email_verified_at))
             router.push('/verify-email')
         
         if (

--- a/src/hooks/auth.js
+++ b/src/hooks/auth.js
@@ -103,7 +103,7 @@ export const useAuth = ({ middleware, redirectIfAuthenticated } = {}) => {
         if (middleware === 'guest' && redirectIfAuthenticated && user)
             router.push(redirectIfAuthenticated)
 
-        if (middleware === 'auth' && !user?.email_verified_at)
+        if (middleware === 'auth' && (user && !user?.email_verified_at))
             router.push('/verify-email')
         
         if (


### PR DESCRIPTION
Added condition to push 'verify-email' route only when user is not undefined to avoid having always this redirection even when the user is not yet in context.

The current condition is pushing always to 'verify-email' route, even when the user doesn't even exists in context yet. If the intention is to verify the actual value for the user 'email_verified_at' attribute, it should be performed when the user exists in context.

Right now this is causing a redirection issue for scenarios where more child routes are added under (app) that need to use the same layout / auth validation / verification. Since the user is not yet present in context at the very beginning of execution, it redirects to 'verify-email' route, then once there, the user already exists (and with valid email validation), and it's redirected back to dashboard page, instead of the intended original one.

This change doesn't impact regular functionality for new registered users or for existent logged users either if they are validated or not. If they are not validated yet, the proper page asking for email validation appears, otherwise, the flow continues as expected.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
