### PR TITLE
Fix startup failures in reusable workflow pins (pull-requests + issues)

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   help-wanted:
-    uses: laravel/.github/.github/workflows/issues.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main
+    uses: laravel/.github/.github/workflows/issues.yml@c265c45c41ccb723befb7a2b807dffff4595bd39 # main

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   uneditable:
-    uses: laravel/.github/.github/workflows/pull-requests.yml@dd86ce0a18475504e42fa809d7454c1cb1a88028 # main
+    uses: laravel/.github/.github/workflows/pull-requests.yml@c265c45c41ccb723befb7a2b807dffff4595bd39 # main


### PR DESCRIPTION
### Problem

The **pull requests** workflow has been failing every run with `startup_failure` since the "GitHub Actions hardening" PR (commit `9618e18`). Example: https://github.com/laravel/breeze-next/actions/runs/26940822568

The **issues** workflow has the identical latent bug — it just hasn't surfaced because no issue has been labeled `help wanted` since.

### Cause

The hardening PR pinned both reusable workflows to `laravel/.github@dd86ce0`. At that SHA both workflows declare more permissions than the callers grant:

| Workflow | Reusable requires (`@dd86ce0`) | Caller grants |
|---|---|---|
| `pull-requests.yml` | `contents: read`, `pull-requests: write` | `pull-requests: write` |
| `issues.yml` | `contents: read`, `issues: write`, `pull-requests: write` | `issues: write` |

A reusable workflow cannot request a permission the caller didn't grant (unlisted scopes default to `none`), so GitHub rejects the run at startup.

### Fix

Bump both pins to the current `main` SHA `c265c45`. After laravel/.github's "Remove unused scopes" change, the reusable workflows only require the scopes the callers already grant (`pull-requests: write` / `issues: write`). This is also the SHA the repo's `dependabot-auto-merge.yml` already pins, keeping all reusable references consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)