### PR TITLE
[test] verify reusable workflow pins — please ignore

### DIFF
--- a/.github/.workflow-pin-test
+++ b/.github/.workflow-pin-test
@@ -1,0 +1,1 @@
+workflow pin verification — safe to delete


### PR DESCRIPTION
Throwaway PR to confirm the `pull requests` workflow no longer fails at startup after #69. Will be closed and the branch deleted once the check runs.